### PR TITLE
Fix singular `ntPrincipalName`

### DIFF
--- a/payloads.go
+++ b/payloads.go
@@ -177,10 +177,11 @@ func (p *Profile) SCEPPayloads() (plds []*SCEPPayload) {
 // See https://developer.apple.com/documentation/devicemanagement/acmecertificate/subjectaltname
 //
 // For SCEP, this is mentioned about the number of entries:
-// You can specify a single string or an array of strings for each key.
-// The values you specify depend on the CA you're using but might
-// include DNS name, URL, or email values. The assumption is the
-// same is true for ACME.
+// You can specify a single string or an array of strings
+// for each key, except for the ntPrincipalName, which can only
+// be a single string. The values you specify depend on the
+// CA you're using but might include DNS name, URL, or email
+// values. The assumption is the same is true for ACME.
 //
 // Single key/string example:
 //
@@ -202,10 +203,10 @@ func (p *Profile) SCEPPayloads() (plds []*SCEPPayload) {
 // </array>
 // </dict>
 type SubjectAltName struct {
-	DNSNames     multiString `plist:"dNSName,omitempty"`
-	NTPrincipals multiString `plist:"ntPrincipalName,omitempty"`
-	RFC822Names  multiString `plist:"rfc822Name,omitempty"`
-	URIs         multiString `plist:"uniformResourceIdentifier,omitempty"`
+	DNSNames    multiString `plist:"dNSName,omitempty"`
+	NTPrincipal string      `plist:"ntPrincipalName,omitempty"`
+	RFC822Names multiString `plist:"rfc822Name,omitempty"`
+	URIs        multiString `plist:"uniformResourceIdentifier,omitempty"`
 }
 
 type multiString []string

--- a/payloads_test.go
+++ b/payloads_test.go
@@ -25,6 +25,22 @@ func Test_multiString_UnmarshalPlist_error(t *testing.T) {
 	}
 }
 
+func Test_multipleNTPrincipalNames_UnmarshalPlist_error(t *testing.T) {
+	plBytes, err := ioutil.ReadFile(filepath.Join("testdata", "multiple-nt-principals-error.mobileconfig"))
+	fatalIf(t, err)
+
+	p := &Profile{}
+	err = plist.Unmarshal(plBytes, p)
+	if err == nil {
+		t.Error("expected an error")
+	}
+
+	expectedErrorMessage := "plist: cannot unmarshal array into Go value of type string"
+	if err.Error() != expectedErrorMessage {
+		t.Errorf("have %q, want %q", err.Error(), expectedErrorMessage)
+	}
+}
+
 func Test_multiString_MarshalPlist(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/testdata/multiple-nt-principals-error.mobileconfig
+++ b/testdata/multiple-nt-principals-error.mobileconfig
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>PayloadContent</key>
+		<array>
+			<dict>
+				<key>PayloadIdentifier</key>
+				<string>com.apple.security.acme.cbdc6238-feec-4171-8784-98e576bbb814</string>
+				<key>PayloadType</key>
+				<string>com.apple.security.acme</string>
+				<key>PayloadUUID</key>
+				<string>cbdc6238-feec-4171-8784-98e576bbb814</string>
+				<key>PayloadVersion</key>
+				<integer>1</integer>
+				<key>SubjectAltName</key>
+				<dict>
+					<key>ntPrincipalName</key>
+					<array>
+						<string>principal1</string>
+						<string>principal12</string>
+					</array>
+				</dict>
+				<key>Subject</key>
+			</dict>
+		</array>
+		<key>PayloadDisplayName</key>
+		<string>ACME DA Certificate</string>
+		<key>PayloadIdentifier</key>
+		<string>com.smallstep.acmedademo</string>
+		<key>PayloadType</key>
+		<string>Configuration</string>
+		<key>PayloadUUID</key>
+		<string>734EEACF-1334-4B65-8E8C-6AC07E9B79E5</string>
+		<key>PayloadVersion</key>
+		<integer>1</integer>
+	</dict>
+</plist>


### PR DESCRIPTION
An erratum was published mentioning that an `ntPrincipalName` has to be singular and doesn't support an array. The full text:

The documentation indicated that all the keys in the SubjectAltName value could be either string or array types. The ntPrincipalName cannot be an array and must be a string. This has been clarified in the description. Note that the type field for the rfc822Name, dNSName, and uniformResourceIdentifier still indicates these are strings. This has not been corrected as the schema does not support polymorphic types.

Source: https://github.com/apple/device-management/blob/seed_iOS-17-0_macOS-14-0/docs/errata.md#profilescomapplesecurityscepyaml